### PR TITLE
Episode reward curves

### DIFF
--- a/baselines/gymnasium/bipedal_walker.py
+++ b/baselines/gymnasium/bipedal_walker.py
@@ -25,19 +25,7 @@ class BipedalWalkerRunner(GymRunner):
         argparse.ArgumentParser:
             The same parser as the input with potentially new arguments added.
         """
-        parser.add_argument("--bs_clip_min", default=-np.inf, type=float)
-        parser.add_argument("--bs_clip_max", default=np.inf, type=float)
-
         parser.add_argument("--learning_rate", default=0.00025, type=float)
-
-        parser.add_argument("--enable_icm", type=int, default=0)
-        parser.add_argument("--icm_inverse_size", type=int, default=32)
-        parser.add_argument("--icm_inverse_depth", type=int, default=2)
-        parser.add_argument("--icm_forward_size", type=int, default=32)
-        parser.add_argument("--icm_forward_depth", type=int, default=2)
-        parser.add_argument("--icm_encoded_obs_dim", type=int, default=9)
-        parser.add_argument("--icm_learning_rate", type=float, default=0.0003)
-        parser.add_argument("--intr_reward_weight", type=float, default=1.0)
         return parser
 
     def run(self):
@@ -73,22 +61,11 @@ class BipedalWalkerRunner(GymRunner):
         critic_kw_args = actor_kw_args.copy()
         critic_kw_args["hidden_size"] = 256
 
-        #lr = LinearScheduler(
-        #    status_key    = "iteration",
-        #    status_max    = 200,
-        #    max_value     = 0.0003,
-        #    min_value     = 0.0001)
-
         policy_args = {\
-            "ac_network"       : FeedForwardNetwork,
-            "actor_kw_args"    : actor_kw_args,
-            "critic_kw_args"   : critic_kw_args,
+            "ac_network"         : FeedForwardNetwork,
+            "actor_kw_args"      : actor_kw_args,
+            "critic_kw_args"     : critic_kw_args,
             "lr"                 : self.cli_args.learning_rate,
-            "enable_icm"         : self.cli_args.enable_icm,
-            "icm_kw_args"        : icm_kw_args,
-            "icm_lr"             : self.cli_args.icm_learning_rate,
-            "bootstrap_clip"     : (bs_clip_min, bs_clip_max),
-            "intr_reward_weight" : self.cli_args.intr_reward_weight,
         }
 
         policy_settings, policy_mapping_fn = get_single_policy_defaults(

--- a/ppo.py
+++ b/ppo.py
@@ -27,6 +27,61 @@ comm      = MPI.COMM_WORLD
 rank      = comm.Get_rank()
 num_procs = comm.Get_size()
 
+class EpisodeScores(object):
+
+    def __init__(self,
+                 env_batch_size,
+                 policy_ids):
+        """
+        """
+
+        self.policy_ids      = policy_ids
+        self.env_batch_size  = env_batch_size
+
+        self.running_scores  = {}
+        self.episode_count   = {}
+        self.finished_scores = {}
+
+        for policy_id in self.policy_ids:
+            self.running_scores[policy_id]  = np.zeros((self.env_batch_size, 1))
+            self.episode_count[policy_id]   = 0
+            self.finished_scores[policy_id] = 0.0
+
+    def add_scores(self, policy_id, scores):
+        """
+        """
+        self.running_scores[policy_id] += scores
+
+    def end_episodes(self, policy_id, episode_idxs):
+        """
+        """
+        self.finished_scores[policy_id] += self.running_scores[policy_id][episode_idxs].sum()
+        self.episode_count[policy_id]   += len(episode_idxs)
+        self.running_scores[policy_id][episode_idxs] = 0.0
+
+    def _clear_episodes(self, policy_id):
+        """
+        """
+        self.episode_count[policy_id]   = 0
+        self.finished_scores[policy_id] = 0
+
+    def get_mean_scores(self):
+        """
+        """
+        scores = {}
+        for policy_id in self.policy_ids:
+            score_sums     = self.finished_scores[policy_id]
+            total_episodes = comm.allreduce(self.episode_count[policy_id], MPI.SUM)
+            total_scores   = comm.allreduce(score_sums, MPI.SUM)
+
+            self._clear_episodes(policy_id)
+
+            if total_episodes > 0:
+                scores[policy_id] = total_scores / total_episodes
+
+        return scores
+
+
 class PPO(object):
 
     def __init__(self,
@@ -59,6 +114,7 @@ class PPO(object):
                  freeze_scheduler    = None,
                  checkpoint_every    = 100,
                  save_train_scores   = True,
+                 save_ep_scores      = True,
                  save_avg_ep_len     = True,
                  save_running_time   = True,
                  save_bs_info        = True,
@@ -172,6 +228,9 @@ class PPO(object):
         save_train_scores: bool
             If True, the extrinsic reward averages
             for each policy are saved every iteration.
+        save_ep_scores: bool
+            If True, the final episode scores (extrinsic reward averages)
+            for eac policy are saved every iteration that they exist.
         save_avg_ep_len: bool
             If True, the average episode length will be saved as
             a curve for plotting.
@@ -323,6 +382,7 @@ class PPO(object):
         self.force_gc            = force_gc
         self.checkpoint_every    = checkpoint_every
         self.save_train_scores   = save_train_scores
+        self.save_ep_scores      = save_ep_scores
         self.save_avg_ep_len     = save_avg_ep_len
         self.save_running_time   = save_running_time
         self.save_bs_info        = save_bs_info
@@ -449,6 +509,7 @@ class PPO(object):
 
         self.curve_path       = os.path.join(state_path, "curves")
         self.train_score_path = os.path.join(self.curve_path, "scores")
+        self.ep_score_path    = os.path.join(self.curve_path, "episode_scores")
         self.ep_len_path      = os.path.join(self.curve_path, "episode_length")
         self.runtime_path     = os.path.join(self.curve_path, "runtime")
         self.bs_min_path      = os.path.join(self.curve_path, "bs_min")
@@ -458,6 +519,10 @@ class PPO(object):
         if self.save_train_scores and rank == 0:
             if not os.path.exists(self.train_score_path):
                 os.makedirs(self.train_score_path)
+
+        if self.save_ep_scores and rank == 0:
+            if not os.path.exists(self.ep_score_path):
+                os.makedirs(self.ep_score_path)
 
         if self.save_avg_ep_len and rank == 0:
             if not os.path.exists(self.ep_len_path):
@@ -598,6 +663,10 @@ class PPO(object):
                 rank_print(f"{sp}agent ids: {policy.agent_ids}")
 
         comm.barrier()
+
+        self.full_len_ep_scores = EpisodeScores(
+            self.env.get_batch_size(),
+            np.array(list(self.policies.keys())))
 
     def get_policy_batches(self, obs, component):
         """
@@ -1677,6 +1746,9 @@ class PPO(object):
                 ep_nat_scores[policy_id]   += natural_reward[agent_id]
                 ep_intr_scores[policy_id]  += intr_reward[agent_id]
 
+                self.full_len_ep_scores.add_scores(policy_id,
+                    natural_reward[agent_id])
+
                 top_reward[policy_id] = max(top_reward[policy_id],
                     natural_reward[agent_id].max())
 
@@ -1713,6 +1785,8 @@ class PPO(object):
 
                     total_nat_scores[policy_id][where_term] += \
                         ep_nat_scores[policy_id][where_term]
+
+                    self.full_len_ep_scores.end_episodes(policy_id, where_term)
 
                     if self.policies[policy_id].enable_icm:
                         total_intr_scores[policy_id][where_term] += \
@@ -2025,6 +2099,7 @@ class PPO(object):
 
             self.freeze_scheduler()
 
+            pre_rollout_timesteps = self.status_dict["global status"]["timesteps"]
             self.rollout()
 
             for policy_id in self.policies:
@@ -2047,16 +2122,19 @@ class PPO(object):
                 self.save(tag=str(iteration))
 
             if self.save_train_scores:
-                self._save_natural_score_avg()
+                self._save_natural_score_avg(pre_rollout_timesteps)
+
+            if self.save_ep_scores:
+                self._save_full_len_episode_scores(pre_rollout_timesteps)
 
             if self.save_avg_ep_len:
-                self._save_average_episode()
+                self._save_average_episode(pre_rollout_timesteps)
 
             if self.save_running_time:
-                self._save_running_time()
+                self._save_running_time(pre_rollout_timesteps)
 
             if self.save_bs_info:
-                self._save_bs_info()
+                self._save_bs_info(pre_rollout_timesteps)
 
             data_loaders = {}
             for policy_id in self.policies:
@@ -2609,10 +2687,47 @@ class PPO(object):
         self.load_env_info(state_path, tag)
         return self.load_status(state_path)
 
-    def _save_natural_score_avg(self):
+    def _write_timestep_scores_to_file(self, filename, timestep, score):
+        """
+        Write a single score and associated timestep to a numpy file
+        for future analysis.
+        """
+        with open(filename, "ab") as out_f:
+            out_data    = np.zeros((1, 2))
+            out_data[0][0] = timestep
+            out_data[0][1] = score
+            np.savetxt(out_f, np.array(out_data))
+
+    def _save_full_len_episode_scores(self, timestep):
+        """
+        Save the "full length episode" scores. These scores will not be
+        truncated during the rollouts. Instead, they are collected across
+        rollouts, once the episode has terminated.
+
+        Parameters:
+        -----------
+        timestep: int
+            The timestep to correlate with the current scores.
+        """
+        episode_scores = self.full_len_ep_scores.get_mean_scores()
+
+        if rank == 0:
+            for policy_id in episode_scores:
+                score = episode_scores[policy_id]
+                score_f = os.path.join(self.ep_score_path,
+                    f"{policy_id}_scores.npy")
+
+                self._write_timestep_scores_to_file(score_f, timestep, score)
+
+    def _save_natural_score_avg(self, timestep):
         """
         Save the natural reward averages of each policy to numpy
-        txt files.
+        files.
+
+        Parameters:
+        -----------
+        timestep: int
+            The timestep to correlate with the current scores.
         """
         if rank == 0:
             for policy_id in self.policies:
@@ -2620,36 +2735,48 @@ class PPO(object):
                 score_f = os.path.join(self.train_score_path,
                     f"{policy_id}_scores.npy")
 
-                with open(score_f, "ab") as out_f:
-                    np.savetxt(out_f, np.array([score]))
+                self._write_timestep_scores_to_file(score_f, timestep, score)
 
-    def _save_average_episode(self):
+    def _save_average_episode(self, timestep):
         """
         Save the average episode length to a numpy txt file.
+
+        Parameters:
+        -----------
+        timestep: int
+            The timestep to correlate with the current scores.
         """
         if rank == 0:
             avg_ep   = self.status_dict["global status"]["average episode"]
             len_file = os.path.join(self.ep_len_path,
                 f"average_episode.npy")
 
-            with open(len_file, "ab") as out_f:
-                np.savetxt(out_f, np.array([avg_ep]))
+            self._write_timestep_scores_to_file(len_file, timestep, avg_ep)
 
-    def _save_running_time(self):
+    def _save_running_time(self, timestep):
         """
         Save the current running time to a numpy txt file.
+
+        Parameters:
+        -----------
+        timestep: int
+            The timestep to correlate with the current scores.
         """
         if rank == 0:
             runtime      = self.status_dict["global status"]["running time"]
             runtime_file = os.path.join(self.runtime_path,
                 f"running_time.npy")
 
-            with open(runtime_file, "ab") as out_f:
-                np.savetxt(out_f, np.array([runtime]))
+            self._write_timestep_scores_to_file(runtime_file, timestep, runtime)
 
-    def _save_bs_info(self):
+    def _save_bs_info(self, timestep):
         """
         Save the current bootstrap min, max, and avg.
+
+        Parameters:
+        -----------
+        timestep: int
+            The timestep to correlate with the current scores.
         """
         if rank == 0:
 
@@ -2658,22 +2785,19 @@ class PPO(object):
                 bs_file = os.path.join(self.bs_min_path,
                     f"{policy_id}_bs_min.npy")
 
-                with open(bs_file, "ab") as out_f:
-                    np.savetxt(out_f, np.array([bs_min]))
+                self._write_timestep_scores_to_file(bs_file, timestep, bs_min)
 
                 bs_max  = self.status_dict[policy_id]["bootstrap range"][1]
                 bs_file = os.path.join(self.bs_max_path,
                     f"{policy_id}_bs_max.npy")
 
-                with open(bs_file, "ab") as out_f:
-                    np.savetxt(out_f, np.array([bs_max]))
+                self._write_timestep_scores_to_file(bs_file, timestep, bs_max)
 
                 bs_avg  = self.status_dict[policy_id]["bootstrap avg"]
                 bs_file = os.path.join(self.bs_avg_path,
                     f"{policy_id}_bs_avg.npy")
 
-                with open(bs_file, "ab") as out_f:
-                    np.savetxt(out_f, np.array([bs_avg]))
+                self._write_timestep_scores_to_file(bs_file, timestep, bs_avg)
 
     def set_test_mode(self, test_mode):
         """

--- a/ppo.py
+++ b/ppo.py
@@ -2730,6 +2730,15 @@ class PPO(object):
         """
         Write a single score and associated timestep to a numpy file
         for future analysis.
+
+        Parameters:
+        -----------
+        filename: str
+            The name of the file to save curve data to.
+        timestep: int/float
+            The timestep to associate with this score.
+        score: float
+            The score to save.
         """
         with open(filename, "ab") as out_f:
             out_data    = np.zeros((1, 2))

--- a/ppo.py
+++ b/ppo.py
@@ -2655,8 +2655,11 @@ class PPO(object):
         self.policies[policy_id].load(state_path, tag)
 
         if self.normalize_values and policy_id in self.value_normalizers:
-            self.value_normalizers[policy_id].load_info(
-                        os.path.join(self.env_info_path, tag))
+            try:
+                self.value_normalizers[policy_id].load_info(
+                            os.path.join(self.env_info_path, tag))
+            except:
+                pass
 
     def direct_load_policy(self, policy_id, policy_path):
         """

--- a/ppoaf_cli.py
+++ b/ppoaf_cli.py
@@ -265,7 +265,7 @@ def cli():
 
     plot_parser.add_argument("--curve_type", type=str, default="scores",
         choices=["scores", "runtime", "episode_length",
-        "bs_min", "bs_max", "bs_avg"],
+        "bs_min", "bs_max", "bs_avg", "episode_scores"],
         help="The 'curve_type' is used to refine searches for saved curves "
         "when the curve file is not explicitly set. For instance, if "
         "a user sets 'curves' to a directory to be searched, the searching "

--- a/ppoaf_cli.py
+++ b/ppoaf_cli.py
@@ -101,7 +101,7 @@ def get_runner_class(runner_file):
 
 def cli():
 
-    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
 
     parent_parser.add_argument("--device", type=str, default="cpu",
         help="Which device to use for training.")
@@ -146,7 +146,7 @@ def cli():
         "'<policy_name>_best', and '<checkpoint_iteration>'. Note that this "
         "argument is ignored when pretrained_policies is used.")
 
-    main_parser = argparse.ArgumentParser()
+    main_parser = argparse.ArgumentParser(allow_abbrev=False)
 
     #
     # Create a subparser for the different commands.
@@ -156,7 +156,7 @@ def cli():
     #
     # 'train' command subparser
     #
-    train_parser = subparser.add_parser("train",
+    train_parser = subparser.add_parser("train", allow_abbrev=False,
         help="Train using a PPO-AF runner.", parents=[parent_parser])
 
     train_parser.add_argument("runner", type=str,
@@ -212,7 +212,7 @@ def cli():
     #
     # 'test' command subparser
     #
-    test_parser = subparser.add_parser("test",
+    test_parser = subparser.add_parser("test", allow_abbrev=False,
         help="Evaluate a trained PPO-AF runner.", parents=[parent_parser])
 
     test_parser.add_argument("state_path", type=str,
@@ -254,7 +254,7 @@ def cli():
     #
     # 'plot' command subparser
     #
-    plot_parser = subparser.add_parser("plot",
+    plot_parser = subparser.add_parser("plot", allow_abbrev=False,
         help="Plot reward curves from trained policies.")
 
     plot_parser.add_argument("curves", type=str, nargs="+", help="Paths to the "
@@ -356,6 +356,8 @@ def cli():
 
     args, runner_args = main_parser.parse_known_args()
     arg_dict = vars(args)
+
+    input(arg_dict)#FIXME
 
     #
     # If we're plotting, that's all we need to do.

--- a/ppoaf_cli.py
+++ b/ppoaf_cli.py
@@ -357,8 +357,6 @@ def cli():
     args, runner_args = main_parser.parse_known_args()
     arg_dict = vars(args)
 
-    input(arg_dict)#FIXME
-
     #
     # If we're plotting, that's all we need to do.
     #

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -31,7 +31,7 @@ def test_mat_mpe_simple_tag_discrete_mpi(num_ranks):
         'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
-    num_timesteps = 250000
+    num_timesteps = 400000
     passing_scores = {"adversary" : 300.0}
 
     run_training(

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -31,7 +31,7 @@ def test_mat_mpe_simple_tag_discrete_mpi(num_ranks):
         'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
-    num_timesteps = 250000
+    num_timesteps = 500000
     passing_scores = {"adversary" : 300.0}
 
     run_training(
@@ -42,7 +42,7 @@ def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
         num_ranks       = num_ranks)
 
     high_score_test('mat mpi mpe simple tag continuous',
-        'mpe_simple_tag.py', 10, passing_scores)
+        'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_agent_shared_icm(num_ranks):
     #

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -31,7 +31,7 @@ def test_mat_mpe_simple_tag_discrete_mpi(num_ranks):
         'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
-    num_timesteps = 250000
+    num_timesteps = 300000
     passing_scores = {"adversary" : 300.0}
 
     run_training(

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -31,7 +31,7 @@ def test_mat_mpe_simple_tag_discrete_mpi(num_ranks):
         'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
-    num_timesteps = 400000
+    num_timesteps = 250000
     passing_scores = {"adversary" : 300.0}
 
     run_training(
@@ -42,7 +42,7 @@ def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
         num_ranks       = num_ranks)
 
     high_score_test('mat mpi mpe simple tag continuous',
-        'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
+        'mpe_simple_tag.py', 10, passing_scores)
 
 def test_agent_shared_icm(num_ranks):
     #

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -31,7 +31,7 @@ def test_mat_mpe_simple_tag_discrete_mpi(num_ranks):
         'mpe_simple_tag.py', 10, passing_scores, options="--policy_tag adversary_best")
 
 def test_mat_mpe_simple_tag_continuous_mpi(num_ranks):
-    num_timesteps = 500000
+    num_timesteps = 250000
     passing_scores = {"adversary" : 300.0}
 
     run_training(

--- a/test/tests/train/test_zoo.py
+++ b/test/tests/train/test_zoo.py
@@ -50,7 +50,7 @@ def test_agent_shared_icm(num_ranks):
     # sure the agent shared ICM setting doesn't cause any crashes.
     #
     num_timesteps = 10000
-    passing_scores = {"agent" : 0.0}
+    passing_scores = {"agent" : -100}
 
     run_training(
         baseline_type   = 'pettingzoo',

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -465,11 +465,11 @@ def plot_curves_with_plotly(
             else:
                 curves.append(data)
 
-    if len(timesteps) > 0:
-        msg  = f"ERROR: timestep data found for some but not all curves. "
-        msg += f"Curves with timestep data can only be plotted with other timestep "
-        msg += f"curves."
-        assert len(timesteps) == len(curves), msg
+    if len(timesteps) > 0 and len(timesteps) != len(curves):
+        msg  = f"\nWARNING: timestep data found for some but not all curves. "
+        msg += f"Resorting to iterations for X axis.\n"
+        sys.stderr.write(msg)
+        timesteps = []
 
     fig = go.Figure()
 
@@ -612,20 +612,21 @@ def plot_grouped_curves_with_plotly(
 
         if auto_group_name and group_name == "":
             group_name = f"group_{g_idx}"
-            msg  = "WARNING: unable to find overlapping group name. "
-            msg += f"Defaulting to generic name '{group_name}'."
-            print(msg)
+            msg  = "\nWARNING: unable to find overlapping group name. "
+            msg += f"Defaulting to generic name '{group_name}'.\n"
+            sys.stderr.write(msg)
 
         if len(timesteps) > 0:
-            msg  = f"ERROR: timestep data found for some but not all curves. "
-            msg += f"Curves with timestep data can only be plotted with other timestep "
-            msg += f"curves."
-            assert len(timesteps) == len(curves), msg
-
-            msg  = f"ERROR: grouping can only occur if the timesteps between curves "
-            msg += f"are identical."
-            for i in range(1, len(timesteps)):
-                assert (timesteps[i-1] == timesteps[i]).all(), msg
+            if len(timesteps) != len(curves):
+                msg  = f"\nWARNING: timestep data found for some but not all curves. "
+                msg += f"Resorting to iterations for X axis.\n"
+                sys.stderr.write(msg)
+                timesteps = []
+            else:
+                msg  = f"ERROR: grouping can only occur if the timesteps between curves "
+                msg += f"are identical."
+                for i in range(1, len(timesteps)):
+                    assert (timesteps[i-1] == timesteps[i]).all(), msg
 
         if len(timesteps) > 0:
             timesteps = timesteps[0]

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -446,6 +446,7 @@ def plot_curves_with_plotly(
         The the file should have an extension that is supported by plotly.
     """
     curves      = []
+    timesteps   = []
     curve_names = []
     for cf in curve_files:
         path_parts = cf.split(os.sep)
@@ -456,7 +457,19 @@ def plot_curves_with_plotly(
 
         curve_names.append(name)
         with open(cf, "rb") as in_f:
-            curves.append(np.loadtxt(in_f))
+            data = np.loadtxt(in_f)
+
+            if len(data.shape) > 1:
+                timesteps.append(data[:,0])
+                curves.append(data[:,1])
+            else:
+                curves.append(data)
+
+    if len(timesteps) > 0:
+        msg  = f"ERROR: timestep data found for some but not all curves. "
+        msg += f"Curves with timestep data can only be plotted with other timestep "
+        msg += f"curves."
+        assert len(timesteps) == len(curves), msg
 
     fig = go.Figure()
 
@@ -465,16 +478,27 @@ def plot_curves_with_plotly(
         mode = f"{mode}+markers"
 
     for i in range(len(curve_names)):
-        iterations = np.arange(curves[i].size)
+
+        if len(timesteps) > 0:
+            x_data = timesteps[i]
+        else:
+            x_data = np.arange(curves[i].size)
+
         fig.add_trace(
             go.Scatter(
-                x      = iterations,
+                x      = x_data,
                 y      = curves[i],
                 mode   = mode,
                 name   = curve_names[i]))
 
+    x_title = ""
+    if len(timesteps) > 0:
+        x_title = "Timesteps"
+    else:
+        x_title = "Iterations"
+
     fig.update_layout(
-        xaxis_title = "Iterations",
+        xaxis_title = x_title,
         yaxis_title = curve_type,
         title       = title,
         title_x     = 0.5,
@@ -552,6 +576,7 @@ def plot_grouped_curves_with_plotly(
             print(f"Group at index {g_idx} is empty. Skipping...")
             continue
 
+        timesteps   = []
         curves      = []
         curve_names = []
         group_color = colors[g_idx]
@@ -577,7 +602,13 @@ def plot_grouped_curves_with_plotly(
                     group_name = get_str_overlap(group_name, name)
 
             with open(cf, "rb") as in_f:
-                curves.append(np.loadtxt(in_f))
+                data = np.loadtxt(in_f)
+
+                if len(data.shape) > 1:
+                    timesteps.append(data[:,0])
+                    curves.append(data[:,1])
+                else:
+                    curves.append(data)
 
         if auto_group_name and group_name == "":
             group_name = f"group_{g_idx}"
@@ -585,12 +616,26 @@ def plot_grouped_curves_with_plotly(
             msg += f"Defaulting to generic name '{group_name}'."
             print(msg)
 
+        if len(timesteps) > 0:
+            msg  = f"ERROR: timestep data found for some but not all curves. "
+            msg += f"Curves with timestep data can only be plotted with other timestep "
+            msg += f"curves."
+            assert len(timesteps) == len(curves), msg
+
+            msg  = f"ERROR: grouping can only occur if the timesteps between curves "
+            msg += f"are identical."
+            for i in range(1, len(timesteps)):
+                assert (timesteps[i-1] == timesteps[i]).all(), msg
+
+        if len(timesteps) > 0:
+            timesteps = timesteps[0]
+
         x_size = curves[0].size
         failed_size_check = False
         for c in curves:
             if x_size != c.size:
                 msg  = "\nERROR: grouped curves must all have the same number "
-                msg += f"of iterations, but group {group_name} does not."
+                msg += f"of values, but group {group_name} does not."
                 msg += f"\ncurves sizes: "
 
                 for i in range(len(curve_names)):
@@ -613,11 +658,14 @@ def plot_grouped_curves_with_plotly(
             dev_min = np.clip(mean - std, deviation_min, np.inf)
             dev_max = np.clip(mean + std, -np.inf, deviation_max)
 
-        iterations = np.arange(x_size)
+        if len(timesteps) > 0:
+            x_data = timesteps
+        else:
+            x_data = np.arange(x_size)
 
         fig.add_trace(
             go.Scatter(
-                x          = iterations,
+                x          = x_data,
                 y          = mean,
                 line       = dict(color=group_color),
                 mode       = mean_mode,
@@ -626,7 +674,7 @@ def plot_grouped_curves_with_plotly(
         std_name = f"{group_name}_std"
         fig.add_trace(
             go.Scatter(
-                x          = np.concatenate([iterations, iterations[::-1]]),
+                x          = np.concatenate([x_data, x_data[::-1]]),
                 y          = np.concatenate([dev_max, dev_min[::-1]]),
                 fill       = 'toself',
                 fillcolor  = group_color,
@@ -635,8 +683,14 @@ def plot_grouped_curves_with_plotly(
                 showlegend = False,
                 name       = std_name))
 
+    x_title = ""
+    if len(timesteps) > 0:
+        x_title = "Timesteps"
+    else:
+        x_title = "Iterations"
+
     fig.update_layout(
-        xaxis_title = "Iterations",
+        xaxis_title = x_title,
         yaxis_title = curve_type,
         title       = title,
         title_x     = 0.5,


### PR DESCRIPTION
This updates plotting in 2 ways:
1. We now save out "episode scores", which are average episode scores that span across rollouts. This resolved the noisy reward signals we get from soft resets when we only plot episode scores from truncated rollout episodes.
2. Saved curves are now 2 dimensional, with the first dimension being the timestep, and the second dimension being the score.
This is backward compatible. 