### PR TITLE
typefix for updating rewards from list to scalar

### DIFF
--- a/environments/filter_wrappers.py
+++ b/environments/filter_wrappers.py
@@ -412,7 +412,7 @@ class RewardNormalizer(IdentityWrapper):
                 for env_idx in range(self.batch_size):
                     self.running_reward[agent_id][env_idx] = \
                         self.running_reward[agent_id][env_idx] * \
-                        self.gamma + reward[agent_id][env_idx]
+                        self.gamma + reward[agent_id][env_idx].squeeze()
 
                     self.running_stats[agent_id].update(
                         self.running_reward[agent_id])


### PR DESCRIPTION
PPOAF was erroring out due to reward being type: list, unwrapping was done using the callable squeeze to fix the error 